### PR TITLE
Fix for #28

### DIFF
--- a/devserver/middleware.py
+++ b/devserver/middleware.py
@@ -23,6 +23,10 @@ class DevServerMiddleware(object):
         return True
     
     def process_request(self, request):
+        # Set a sentinel value which process_response can use to abort when
+        # another middleware app short-circuits processing:
+        request._devserver_active = True
+
         self.process_init(request)
         
         if self.should_process(request):
@@ -30,6 +34,13 @@ class DevServerMiddleware(object):
                 mod.process_request(request)
     
     def process_response(self, request, response):
+        # If this isn't set, it usually means that another middleware layer
+        # has returned an HttpResponse and the following middleware won't see
+        # the request. This happens most commonly with redirections - see
+        # https://github.com/dcramer/django-devserver/issues/28 for details:
+        if not getattr(request, "_devserver_active", False):
+            return response
+
         if self.should_process(request):
             for mod in MODULES:
                 mod.process_response(request, response)


### PR DESCRIPTION
This doesn't allow profiling other middleware classes when they do something
which returns a direct HttpResponse but it does avoid crashing every time
something triggers a redirect.
