### PR TITLE
prevent devserver from clobbering the default wsgi application if wsgi_app option is not provided

### DIFF
--- a/devserver/management/commands/runserver.py
+++ b/devserver/management/commands/runserver.py
@@ -134,8 +134,6 @@ class Command(BaseCommand):
                     app = __import__(wsgi_app, {}, {}, ['application']).application
                 except (ImportError, AttributeError):
                     raise
-            else:
-                app = None
 
             if options['use_forked']:
                 mixin = SocketServer.ForkingMixIn


### PR DESCRIPTION
(tested with dcramer/django-devserver@d870ea6a7fb5d7c73dcbb005ca48787fa9e01666 and django/django@2d060eaa44d9ff0a3e18493006e345b77977985a) 

if the wsgi_app option is not provided, you get a traceback like this since the wsgi app gets set to `None`

```
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/wsgiref/handlers.py", line 85, in run
    self.result = application(self.environ, self.start_response)
  File "/Users/tkaemming/Projects/projectname/src/django/django/contrib/staticfiles/handlers.py", line 67, in __call__
    return self.application(environ, start_response)
TypeError: 'NoneType' object is not callable
```
