### PR TITLE
AdminMediaHandler is removed in Django 1.5

### DIFF
--- a/devserver/management/commands/runserver.py
+++ b/devserver/management/commands/runserver.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError, handle_default_options
-from django.core.servers.basehttp import AdminMediaHandler, WSGIServerException, \
-                                         WSGIServer
+from django.core.servers.basehttp import WSGIServerException, WSGIServer
 from django.core.handlers.wsgi import WSGIHandler
 
 import os
@@ -163,7 +162,14 @@ class Command(BaseCommand):
                 from django.contrib.staticfiles.handlers import StaticFilesHandler
                 app = StaticFilesHandler(app)
             else:
-                app = AdminMediaHandler(app, admin_media_path)
+                # AdminMediaHandler is removed in Django 1.5
+                # Add it only when it avialable.
+                try:
+                    from django.core.servers.basehttp import AdminMediaHandler
+                except ImportError:
+                    pass
+                else:
+                    app = AdminMediaHandler(app, admin_media_path)
 
             if options['use_dozer']:
                 from dozer import Dozer


### PR DESCRIPTION
Import AdminMediaHandler only when it is available.
