### PR TITLE
Increase server request_queue_size fixing bug in OS X/Chrome.

### DIFF
--- a/devserver/management/commands/runserver.py
+++ b/devserver/management/commands/runserver.py
@@ -26,6 +26,7 @@ def run(addr, port, wsgi_handler, mixin=None):
     else:
         new = WSGIServer
     server_address = (addr, port)
+    new.request_queue_size = 10
     httpd = new(server_address, SlimWSGIRequestHandler)
     httpd.set_app(wsgi_handler)
     httpd.serve_forever()


### PR DESCRIPTION
Referencing this bug: https://code.djangoproject.com/ticket/18336

http://code.google.com/p/chromium/issues/detail?id=105308

I'm not sure if this is the most appropriate place for this pull request but here's the argument for. This is a reproducable bug using OS X/Chrome combo when there are too many concurrent requests. To be honest, this is more of a bug in Chrome. However, it is marked as WontFix and probably won't be fixed with any hurry because no production server will have a low request_queue_size - indeed this is a problem only in local dev.

Django has been hesitant to patch this because 1. it is addressing a particular environment combo, and 2. that is pretty much a Chrome bug.

But seeing as devserver is more about being ahead of the curve, I thought this would be the best place in the short term while it takes a few months/years for the actual bug to be fixed.
