### PR TITLE
Set default server address

### DIFF
--- a/devserver/management/commands/runserver.py
+++ b/devserver/management/commands/runserver.py
@@ -79,7 +79,7 @@ class Command(BaseCommand):
             raise CommandError('Usage is runserver %s' % self.args)
 
         if not addrport:
-            addr = getattr(settings, 'DEVSERVER_DEFAULT_ADDR', '')
+            addr = getattr(settings, 'DEVSERVER_DEFAULT_ADDR', '127.0.0.1')
             port = getattr(settings, 'DEVSERVER_DEFAULT_PORT', '8000')
             addrport = '%s:%s' % (addr, port)
 


### PR DESCRIPTION
I think it got lost in this commit: https://github.com/dcramer/django-devserver/commit/2c373171791fd5adc9d9fe2729aa6ead0e0423f4
