### PR TITLE
Handle removal of WSGIServerException in Django 1.6

### DIFF
--- a/devserver/testcases.py
+++ b/devserver/testcases.py
@@ -5,9 +5,15 @@ import threading
 from django.conf import settings
 from django.core.handlers.wsgi import WSGIHandler
 from django.core.management import call_command
-from django.core.servers.basehttp import WSGIServer, AdminMediaHandler, WSGIServerException
+from django.core.servers.basehttp import WSGIServer, AdminMediaHandler
 
 from devserver.utils.http import SlimWSGIRequestHandler
+
+try:
+    from django.core.servers.basehttp import (WSGIServerException as
+                                              wsgi_server_exc_cls)
+except ImportError:  # Django 1.6
+    wsgi_server_exc_cls = socket.error
 
 
 class StoppableWSGIServer(WSGIServer):
@@ -52,7 +58,7 @@ class ThreadedTestServerThread(threading.Thread):
             httpd = new(server_address, SlimWSGIRequestHandler)
             httpd.set_app(handler)
             self.started.set()
-        except WSGIServerException, e:
+        except wsgi_server_exc_cls, e:
             self.error = e
             self.started.set()
             return


### PR DESCRIPTION
`WSGIServerException` was replaced with `socket.error` in Django 1.6.
See https://github.com/django/django/commit/56201fe5a85ead96f00d8ad2eda5cfd2bc4cb4b0

This patch fixes the resulting ImportError and preserves compatibility with older Django versions.
