### PR TITLE
Avoiding TypeError when raw sql and no params

### DIFF
--- a/devserver/modules/sql.py
+++ b/devserver/modules/sql.py
@@ -64,7 +64,7 @@ class DatabaseStatTracker(DatabaseStatTracker):
     logger = None
 
     def execute(self, sql, params=()):
-        formatted_sql = sql % (params if isinstance(params, dict) else tuple(params))
+        formatted_sql = params and sql % (params if isinstance(params, dict) else tuple(params)) or sql
         if self.logger:
             message = formatted_sql
             if settings.DEVSERVER_FILTER_SQL:


### PR DESCRIPTION
sql = u'SELECT (strftime(\'%Y%W\', datetime)) AS "week", AVG("core_expense"."amount") AS "average", SUM("core_expense"."amount") AS "total" FROM "core_expense" GROUP BY strftime(\'%Y%W\', datetime), (strftime(\'%Y%W\', datetime)) ORDER BY "week" ASC'

params = ()

When we try raw SQL queries like the one above, mainly when using builtin sql functions of the dbms, and devserver tries to print the queries, we get a "TypeError: not enough arguments for format string"
