### PR TITLE
Remove an excess '%s' from the sql format string.

### DIFF
--- a/devserver/modules/sql.py
+++ b/devserver/modules/sql.py
@@ -106,7 +106,7 @@ class DatabaseStatTracker(DatabaseStatTracker):
             if self.logger:
                 message = sqlparse.format(sql, reindent=True, keyword_case='upper')
 
-                message = 'Executed %s times\n%s' % message
+                message = 'Executed %s times\n' % message
 
                 self.logger.debug(message, duration=duration)
                 self.logger.debug('Found %s matching rows', self.cursor.rowcount, duration=duration, id='query')


### PR DESCRIPTION
There are two `%s` inside the format string, but on one value.

This bug was introduced  in 2010.  It was not noticed probably because `executemany()` can only be triggered by raw sql,
