### PR TITLE
Fix SQLRealTimeModule to work in Django 1.7

### DIFF
--- a/devserver/modules/sql.py
+++ b/devserver/modules/sql.py
@@ -12,7 +12,10 @@ except ImportError:
     from django.db import connection
     connections = {'default': connection}
 
-from django.db.backends import util
+try:
+    from django.db.backends import utils
+except ImportError:
+    from django.db.backends import util as utils  # Django < 1.7
 from django.conf import settings as django_settings
 #from django.template import Node
 
@@ -52,9 +55,9 @@ except ImportError:
     import django
     version = float('.'.join([str(x) for x in django.VERSION[:2]]))
     if version >= 1.6:
-        DatabaseStatTracker = util.CursorWrapper
+        DatabaseStatTracker = utils.CursorWrapper
     else:
-        DatabaseStatTracker = util.CursorDebugWrapper
+        DatabaseStatTracker = utils.CursorDebugWrapper
 
 
 class DatabaseStatTracker(DatabaseStatTracker):
@@ -126,14 +129,14 @@ class SQLRealTimeModule(DevServerModule):
     logger_name = 'sql'
 
     def process_init(self, request):
-        if not issubclass(util.CursorDebugWrapper, DatabaseStatTracker):
-            self.old_cursor = util.CursorDebugWrapper
-            util.CursorDebugWrapper = DatabaseStatTracker
+        if not issubclass(utils.CursorDebugWrapper, DatabaseStatTracker):
+            self.old_cursor = utils.CursorDebugWrapper
+            utils.CursorDebugWrapper = DatabaseStatTracker
         DatabaseStatTracker.logger = self.logger
 
     def process_complete(self, request):
-        if issubclass(util.CursorDebugWrapper, DatabaseStatTracker):
-            util.CursorDebugWrapper = self.old_cursor
+        if issubclass(utils.CursorDebugWrapper, DatabaseStatTracker):
+            utils.CursorDebugWrapper = self.old_cursor
 
 
 class SQLSummaryModule(DevServerModule):


### PR DESCRIPTION
In Django 1.7 `django.db.backends.util` is deprecated and not used, patching it has no effect,
resulting in no sql output in console.