### PR TITLE
Show request time and SQL info when using --werkzeug.

### DIFF
--- a/devserver/management/commands/runserver.py
+++ b/devserver/management/commands/runserver.py
@@ -145,6 +145,8 @@ class Command(BaseCommand):
                 self.stderr.write("WARNING: Unable to initialize werkzeug: %s\n" % e)
                 use_werkzeug = False
             else:
+                from devserver.utils.http_werkzeug import (
+                    SlimWSGIRequestHandler as WerkzeugSlimWSGIRequestHandler)
                 from django.views import debug
                 debug.technical_500_response = null_technical_500_response
 
@@ -201,7 +203,8 @@ class Command(BaseCommand):
             if use_werkzeug:
                 run_simple(
                     self.addr, int(self.port), DebuggedApplication(app, True),
-                    use_reloader=False, use_debugger=True)
+                    use_reloader=False, use_debugger=True,
+                    request_handler=WerkzeugSlimWSGIRequestHandler)
             else:
                 run(self.addr, int(self.port), app, mixin, ipv6=options['use_ipv6'])
 

--- a/devserver/utils/http_werkzeug.py
+++ b/devserver/utils/http_werkzeug.py
@@ -1,0 +1,59 @@
+from datetime import datetime
+
+from django.conf import settings
+from werkzeug.serving import WSGIRequestHandler
+
+try:
+    from django.db import connections
+except ImportError:
+    # Django version < 1.2
+    from django.db import connection
+    connections = {'default': connection}
+
+from devserver.utils.time import ms_from_timedelta
+
+
+class SlimWSGIRequestHandler(WSGIRequestHandler):
+    """
+    Hides all requests that originate from either ``STATIC_URL`` or ``MEDIA_URL``
+    as well as any request originating with a prefix included in
+    ``DEVSERVER_IGNORED_PREFIXES``.
+    """
+    def handle(self, *args, **kwargs):
+        self._start_request = datetime.now()
+        return super(SlimWSGIRequestHandler, self).handle(*args, **kwargs)
+
+    def log(self, type, message, *args):
+        if type != 'info':
+            return super(SlimWSGIRequestHandler, self).log(type, message,
+                                                           *args)
+
+        duration = datetime.now() - self._start_request
+
+        env = self.make_environ()
+
+        for url in (getattr(settings, 'STATIC_URL', None), settings.MEDIA_URL):
+            if not url:
+                continue
+            if self.path.startswith(url):
+                return
+            elif url.startswith('http:'):
+                if (('http://%s%s' % (env['HTTP_HOST'], self.path))
+                        .startswith(url)):
+                    return
+
+        for path in getattr(settings, 'DEVSERVER_IGNORED_PREFIXES', []):
+            if self.path.startswith(path):
+                return
+
+        format = ' (time: %.2fs; sql: %dms (%dq))'
+        queries = [
+            q for alias in connections
+            for q in connections[alias].queries
+        ]
+        message += format % (
+            ms_from_timedelta(duration) / 1000,
+            sum(float(c.get('time', 0)) for c in queries) * 1000,
+            len(queries),
+        )
+        return super(SlimWSGIRequestHandler, self).log(type, message, *args)


### PR DESCRIPTION
Fixes #110 by taking the code in `http.py` and using Werkzeug's version of `WSGIRequestHandler`, and adding some Werkzeug-specific changes. This file only gets loaded when `--werkzeug` is used.
