### PR TITLE
Django >=1.8 compatibility for the use_ipv6 manangement command option

### DIFF
--- a/devserver/management/commands/runserver.py
+++ b/devserver/management/commands/runserver.py
@@ -203,7 +203,7 @@ class Command(BaseCommand):
                     self.addr, int(self.port), DebuggedApplication(app, True),
                     use_reloader=False, use_debugger=True)
             else:
-                run(self.addr, int(self.port), app, mixin, ipv6=options['use_ipv6'])
+                run(self.addr, int(self.port), app, mixin, ipv6=self.use_ipv6)
 
         except wsgi_server_exc_cls, e:
             # Use helpful error messages instead of ugly tracebacks.


### PR DESCRIPTION
Under Django 1.8, if devserver is run without the --werkzeug option it will fail to start with the error:

``` 
 File "/.../src/django-devserver/devserver/management/commands/runserver.py", line 206, in inner_run
    run(self.addr, int(self.port), app, mixin, ipv6=options['use_ipv6'])
KeyError: 'use_ipv6'
```

This is because Django 1.8 [changes management commands to use argparse rather than optparse](https://docs.djangoproject.com/en/dev/releases/1.8/#management-commands-that-only-accept-positional-arguments).

As a result the `options` kwargs no longer gets any of the options of its `BaseCommand` (Django's runserver) by way of the concaternation that makes the `option_list`. The `ipv6` option comes from the `BaseCommand`.

However, since the `BaseCommand` sets `self.use_ipv6 = options.get('use_ipv6')`, the devserver command can just use `self.use_ipv6` instead of `options['use_ipv6']`.

This is backwards compatible for Django < 1.8 since earlier versions Django's runserver also set `self.use_ipv6`.
