### PR TITLE
Fix django class based view method decorator

### DIFF
--- a/devserver/modules/profile.py
+++ b/devserver/modules/profile.py
@@ -129,7 +129,7 @@ else:
                 request = args[0]
                 if hasattr(request, 'request'):
                     # We're decorating a Django class-based-view and the first argument is actually self:
-                    request = args[1]
+                    request = request.request
 
                 try:
                     request.devserver_profiler.add_function(func)


### PR DESCRIPTION
Now it can be applied to any method of class based view, request doesn't required as second argument of method