### PR TITLE
Make autoreload work under Django >= 1.8

### DIFF
--- a/devserver/__init__.py
+++ b/devserver/__init__.py
@@ -53,7 +53,7 @@ def patch_get_commands():
     # Make autoreload use the devserver's runserver command instead of the
     # default one. This prevent crashing the devserver on a syntax error
     import functools
-    import django.core.management.get_commands
+    import django.core.management
 
     original = django.core.management.get_commands
     if getattr(original, '_wrapped', False):


### PR DESCRIPTION
Currently if you have a syntax error in any of your files the application and you used non-standard runserver arguments (ie. --wsgi-app) it will crash the running server with the following error:

```
Using WSGI application 'common.wsgi'
usage: manage.py runserver [-h] [--version] [-v {0,1,2,3}]
                           [--settings SETTINGS] [--pythonpath PYTHONPATH]
                           [--traceback] [--no-color] [--ipv6] [--nothreading]
                           [--noreload]
                           [addrport]
manage.py runserver: error: unrecognized arguments: --wsgi-app=common.wsgi
```

This PR fixes the issue by patching `get_commands` to always return the runserver command from the devserver package. The patch is only applied to Django>=1.8
