### PR TITLE
Fix syntaxError and make it compatible with python3

### DIFF
--- a/devserver/models.py
+++ b/devserver/models.py
@@ -46,17 +46,17 @@ def load_modules():
         try:
             name, class_name = path.rsplit('.', 1)
         except ValueError:
-            raise exceptions.ImproperlyConfigured, '%s isn\'t a devserver module' % path
+            raise exceptions.ImproperlyConfigured("%s isn\'t a devserver module" % path)
 
         try:
             module = __import__(name, {}, {}, [''])
-        except ImportError, e:
-            raise exceptions.ImproperlyConfigured, 'Error importing devserver module %s: "%s"' % (name, e)
+        except ImportError as e:
+            raise exceptions.ImproperlyConfigured("Error importing devserver module %s: %s" % (name, e))
 
         try:
             cls = getattr(module, class_name)
         except AttributeError:
-            raise exceptions.ImproperlyConfigured, 'Error importing devserver module "%s" does not define a "%s" class' % (name, class_name)
+            raise exceptions.ImproperlyConfigured("Error importing devserver module %s does not define a %s class" % (name, class_name))
 
         try:
             instance = cls(GenericLogger(cls))


### PR DESCRIPTION
Fix #109

```
File "/home/js/.virtualenvs/ppm/lib64/python3.4/site-packages/devserver/models.py", line 20
    raise exceptions.ImproperlyConfigured, '%s isn\'t a devserver module' % path
                                         ^
SyntaxError: invalid syntax
```