### PR TITLE
Solved issue #132 (maximum recursion depth exceeded on Django 1.10)

### DIFF
--- a/devserver/modules/sql.py
+++ b/devserver/modules/sql.py
@@ -53,8 +53,11 @@ try:
 except ImportError:
     debug_toolbar = False
     import django
-    version = float('.'.join([str(x) for x in django.VERSION[:2]]))
-    if version >= 1.6:
+    #version = float('.'.join([str(x) for x in django.VERSION[:2]]))
+    #if version >= 1.6:
+    # Version comparison fix required after Django 1.10
+    version = django.VERSION[0] * 100 + django.VERSION[1]
+    if version >= 106:
         DatabaseStatTracker = utils.CursorWrapper
     else:
         DatabaseStatTracker = utils.CursorDebugWrapper


### PR DESCRIPTION
Version comparison fix required after Django 1.10